### PR TITLE
fix jose builder

### DIFF
--- a/lib/mix2nix.ex
+++ b/lib/mix2nix.ex
@@ -52,6 +52,8 @@ defmodule Mix2nix do
 		cond do
 			pkgname == "cowboy" ->
 				"buildErlangMk"
+			pkgname == "jose" ->
+				"buildMix"
 			Enum.member?(builders, :rebar3) ->
 				"buildRebar3"
 			Enum.member?(builders, :mix) ->


### PR DESCRIPTION
I'm just adding this bandaid for now just so that mix2nix is not "broken" for people using it.

I completely agree with you that we should have a longer term approach. I'm adding this fix so we can get time to think of something better.

Let me know if it makes sense.

I can take care of updating nixpkgs upstream.

closes https://github.com/ydlr/mix2nix/issues/4