### PR TITLE
use tarball sha256 if present

### DIFF
--- a/lib/mix2nix.ex
+++ b/lib/mix2nix.ex
@@ -91,8 +91,8 @@ defmodule Mix2nix do
 
 	def nix_expression(
 		allpkgs,
-		{:hex, name, version, _hash, builders, deps, "hexpm", _hash2}
-	), do: get_hexpm_expression(allpkgs, name, version, builders, deps)
+		{:hex, name, version, _hash, builders, deps, "hexpm", hash2}
+	), do: get_hexpm_expression(allpkgs, name, version, builders, deps, hash2)
 
 	def nix_expression(
 		allpkgs,
@@ -103,10 +103,10 @@ defmodule Mix2nix do
 		""
 	end
 
-	defp get_hexpm_expression(allpkgs, name, version, builders, deps) do
+	defp get_hexpm_expression(allpkgs, name, version, builders, deps, sha256 \\ nil) do
 		name = Atom.to_string(name)
 		buildEnv = get_build_env(builders, name)
-		sha256 = get_hash(name, version)
+		sha256 = sha256 || get_hash(name, version)
 		deps = dep_string(allpkgs, deps)
 
 		"""


### PR DESCRIPTION
The newer hash has the advantage that it can be directly used with fetchurl without having to do an extra `nix-prefetch-url` step.

It means that `mix2nix` can then also be used as an import-from-derivation/in a sandboxed nix build!

Something like this:

```nix
let
  nixified = pkgs.runCommand "nixified-mix" {} "${pkgs.mix2nix}/bin/mix2nix ${./mix.lock} > $out";
in
pkgs.beamPackages.mixRelease {
  inherit pname version src;
  mixNixDeps = import nixified { lib = pkgs.lib; beamPackages = pkgs.beamPackages; };
}
```