### PR TITLE
fix names to match app names

### DIFF
--- a/lib/mix2nix.ex
+++ b/lib/mix2nix.ex
@@ -114,11 +114,11 @@ defmodule Mix2nix do
 
 		"""
 		    #{name} = #{buildEnv} rec {
-		      name = "#{hex_name}";
+		      name = "#{name}";
 		      version = "#{version}";
 
 		      src = fetchHex {
-		        pkg = "${name}";
+		        pkg = "#{hex_name}";
 		        version = "${version}";
 		        sha256 = "#{sha256}";
 		      };

--- a/test/result.nix
+++ b/test/result.nix
@@ -13,7 +13,7 @@ let
       version = "2.9.0";
 
       src = fetchHex {
-        pkg = "${name}";
+        pkg = "cowboy";
         version = "${version}";
         sha256 = "2c729f934b4e1aa149aff882f57c6372c15399a20d54f65c8d67bef583021bde";
       };
@@ -26,7 +26,7 @@ let
       version = "2.11.0";
 
       src = fetchHex {
-        pkg = "${name}";
+        pkg = "cowlib";
         version = "${version}";
         sha256 = "2b3e9da0b21c4565751a6d4901c20d1b4cc25cbb7fd50d91d2ab6dd287bc86a9";
       };
@@ -39,7 +39,7 @@ let
       version = "2.0.0";
 
       src = fetchHex {
-        pkg = "${name}";
+        pkg = "decimal";
         version = "${version}";
         sha256 = "34666e9c55dea81013e77d9d87370fe6cb6291d1ef32f46a1600230b1d44f577";
       };
@@ -52,7 +52,7 @@ let
       version = "3.9.4";
 
       src = fetchHex {
-        pkg = "${name}";
+        pkg = "ecto";
         version = "${version}";
         sha256 = "de5f988c142a3aa4ec18b85a4ec34a2390b65b24f02385c1144252ff6ff8ee75";
       };
@@ -65,7 +65,7 @@ let
       version = "1.4.0";
 
       src = fetchHex {
-        pkg = "${name}";
+        pkg = "jason";
         version = "${version}";
         sha256 = "79a3791085b2a0f743ca04cec0f7be26443738779d09302e01318f97bdb82121";
       };
@@ -78,7 +78,7 @@ let
       version = "1.8.0";
 
       src = fetchHex {
-        pkg = "${name}";
+        pkg = "ranch";
         version = "${version}";
         sha256 = "1rfz5ld54pkd2w25jadyznia2vb7aw9bclck21fizargd39wzys9";
       };
@@ -91,7 +91,7 @@ let
       version = "1.2.1";
 
       src = fetchHex {
-        pkg = "${name}";
+        pkg = "telemetry";
         version = "${version}";
         sha256 = "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5";
       };


### PR DESCRIPTION
Unfortunately, I didn't actually try the final version of #17 against my project, so I just tried to use the merged version and found that using the hex package name for the outer package doesn't actually work. It seems like packages are looking for their dependencies under the application name, so using the hex package name means the dependency can't be found. For instance, grpcbox can't find chatterbox because it's not in a directory named chatterbox, it's erroneously called ts_chatterbox.

```
===> Analyzing applications...
===> Compiling grpcbox
===> Compiling src/grpcbox.erl failed
src/grpcbox.erl:{11,14}: can't find include lib "chatterbox/include/http2.hrl"; Make sure chatterbox is in your app file's 'applications' list
```

I think I knew this at one point but had forgotten it. This PR goes back to the approach I originally submitted in #17, where the package name is based on the application name.