### PR TITLE
Add .formatter.exs and use default formatting

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,3 @@
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/mix2nix.ex
+++ b/lib/mix2nix.ex
@@ -1,148 +1,155 @@
 defmodule Mix2nix do
-	def process(filename) do
-		filename
-		|> read
-		|> expression_set
-	end
+  def process(filename) do
+    filename
+    |> read
+    |> expression_set
+  end
 
-	def expression_set(deps) do
-		deps
-		|> Map.to_list()
-		|> Enum.sort(:asc)
-		|> Enum.map(fn {k, v} -> nix_expression(deps, k, v) end)
-		|> Enum.reject(fn x -> x == "" end)
-		|> Enum.join("\n")
-		|> String.trim("\n")
-		|> wrap
-	end
+  def expression_set(deps) do
+    deps
+    |> Map.to_list()
+    |> Enum.sort(:asc)
+    |> Enum.map(fn {k, v} -> nix_expression(deps, k, v) end)
+    |> Enum.reject(fn x -> x == "" end)
+    |> Enum.join("\n")
+    |> String.trim("\n")
+    |> wrap
+  end
 
-	defp read(filename) do
-		opts = [file: filename, warn_on_unnecessary_quotes: false]
+  defp read(filename) do
+    opts = [file: filename, warn_on_unnecessary_quotes: false]
 
-		with {:ok, contents} <- File.read(filename),
-		     {:ok, quoted} <- Code.string_to_quoted(contents, opts),
-		     {%{} = lock, _} <- Code.eval_quoted(quoted, opts) do
-			lock
-		else
-			{:error, posix} when is_atom(posix) ->
-				:file.format_error(posix) |> to_string() |> IO.puts()
-				System.halt(1)
+    with {:ok, contents} <- File.read(filename),
+         {:ok, quoted} <- Code.string_to_quoted(contents, opts),
+         {%{} = lock, _} <- Code.eval_quoted(quoted, opts) do
+      lock
+    else
+      {:error, posix} when is_atom(posix) ->
+        :file.format_error(posix) |> to_string() |> IO.puts()
+        System.halt(1)
 
-			{:error, {line, error, token}} when is_integer(line) ->
-				IO.puts("Error on line #{line}: #{error} (" <> inspect(token) <> ")")
-				System.halt(1)
-		end
-	end
+      {:error, {line, error, token}} when is_integer(line) ->
+        IO.puts("Error on line #{line}: #{error} (" <> inspect(token) <> ")")
+        System.halt(1)
+    end
+  end
 
-	def is_required(allpkgs, [ hex: name, repo: _, optional: optional ]) do
-		Map.has_key?(allpkgs, name) or ! optional
-	end
+  def is_required(allpkgs, hex: name, repo: _, optional: optional) do
+    Map.has_key?(allpkgs, name) or !optional
+  end
 
-	def dep_string(allpkgs, deps) do
-		depString =
-			deps
-			|> Enum.filter(fn x -> is_required(allpkgs, elem(x, 2)) end)
-			|> Enum.map(fn x -> Atom.to_string(elem(x, 0)) end)
-			|> Enum.join(" ")
+  def dep_string(allpkgs, deps) do
+    depString =
+      deps
+      |> Enum.filter(fn x -> is_required(allpkgs, elem(x, 2)) end)
+      |> Enum.map(fn x -> Atom.to_string(elem(x, 0)) end)
+      |> Enum.join(" ")
 
-		if String.length(depString) > 0 do
-			"[ " <> depString <> " ]"
-		else
-			"[]"
-		end
-	end
+    if String.length(depString) > 0 do
+      "[ " <> depString <> " ]"
+    else
+      "[]"
+    end
+  end
 
-	def specific_workaround(pkg) do
-		case pkg do
-			"cowboy" -> "buildErlangMk"
-			"ssl_verify_fun" -> "buildRebar3"
-			"jose" -> "buildMix"
-			_ -> false
-		end
-	end
+  def specific_workaround(pkg) do
+    case pkg do
+      "cowboy" -> "buildErlangMk"
+      "ssl_verify_fun" -> "buildRebar3"
+      "jose" -> "buildMix"
+      _ -> false
+    end
+  end
 
-	def get_build_env(builders, pkgname) do
-		cond do
-			specific_workaround(pkgname) ->
-				specific_workaround(pkgname)
-			Enum.member?(builders, :mix) ->
-				"buildMix"
-			Enum.member?(builders, :rebar3) or Enum.member?(builders, :rebar) ->
-				"buildRebar3"
-			Enum.member?(builders, :make) ->
-				"buildErlangMk"
-			true ->
-				"buildMix"
-		end
-	end
+  def get_build_env(builders, pkgname) do
+    cond do
+      specific_workaround(pkgname) ->
+        specific_workaround(pkgname)
 
-	def get_hash(name, version) do
-		url = "https://repo.hex.pm/tarballs/#{name}-#{version}.tar"
-		{ result, status } = System.cmd("nix-prefetch-url", [url])
+      Enum.member?(builders, :mix) ->
+        "buildMix"
 
-		case status do
-			0 ->
-				String.trim(result)
-			_ ->
-				IO.puts("Use of nix-prefetch-url failed.")
-				System.halt(1)
-		end
-	end
+      Enum.member?(builders, :rebar3) or Enum.member?(builders, :rebar) ->
+        "buildRebar3"
 
-	def nix_expression(
-		allpkgs,
-		name,
-		{:hex, hex_name, version, _hash, builders, deps, "hexpm", hash2}
-	), do: get_hexpm_expression(allpkgs, name, hex_name, version, builders, deps, hash2)
+      Enum.member?(builders, :make) ->
+        "buildErlangMk"
 
-	def nix_expression(
-		allpkgs,
-		name,
-		{:hex, hex_name, version, _hash, builders, deps, "hexpm"}
-	), do: get_hexpm_expression(allpkgs, name, hex_name, version, builders, deps)
+      true ->
+        "buildMix"
+    end
+  end
 
-	def nix_expression(_allpkgs, _name, _pkg) do
-		""
-	end
+  def get_hash(name, version) do
+    url = "https://repo.hex.pm/tarballs/#{name}-#{version}.tar"
+    {result, status} = System.cmd("nix-prefetch-url", [url])
 
-	defp get_hexpm_expression(allpkgs, name, hex_name, version, builders, deps, sha256 \\ nil) do
-	  name = Atom.to_string(name)
-		hex_name = Atom.to_string(hex_name)
-		buildEnv = get_build_env(builders, name)
-		sha256 = sha256 || get_hash(hex_name, version)
-		deps = dep_string(allpkgs, deps)
+    case status do
+      0 ->
+        String.trim(result)
 
-		"""
-		    #{name} = #{buildEnv} rec {
-		      name = "#{name}";
-		      version = "#{version}";
+      _ ->
+        IO.puts("Use of nix-prefetch-url failed.")
+        System.halt(1)
+    end
+  end
 
-		      src = fetchHex {
-		        pkg = "#{hex_name}";
-		        version = "${version}";
-		        sha256 = "#{sha256}";
-		      };
+  def nix_expression(
+        allpkgs,
+        name,
+        {:hex, hex_name, version, _hash, builders, deps, "hexpm", hash2}
+      ),
+      do: get_hexpm_expression(allpkgs, name, hex_name, version, builders, deps, hash2)
 
-		      beamDeps = #{deps};
-		    };
-		"""
-	end
+  def nix_expression(
+        allpkgs,
+        name,
+        {:hex, hex_name, version, _hash, builders, deps, "hexpm"}
+      ),
+      do: get_hexpm_expression(allpkgs, name, hex_name, version, builders, deps)
 
-	defp wrap(pkgs) do
-		"""
-		{ lib, beamPackages, overrides ? (x: y: {}) }:
+  def nix_expression(_allpkgs, _name, _pkg) do
+    ""
+  end
 
-		let
-		  buildRebar3 = lib.makeOverridable beamPackages.buildRebar3;
-		  buildMix = lib.makeOverridable beamPackages.buildMix;
-		  buildErlangMk = lib.makeOverridable beamPackages.buildErlangMk;
+  defp get_hexpm_expression(allpkgs, name, hex_name, version, builders, deps, sha256 \\ nil) do
+    name = Atom.to_string(name)
+    hex_name = Atom.to_string(hex_name)
+    buildEnv = get_build_env(builders, name)
+    sha256 = sha256 || get_hash(hex_name, version)
+    deps = dep_string(allpkgs, deps)
 
-		  self = packages // (overrides self packages);
+    """
+        #{name} = #{buildEnv} rec {
+          name = "#{name}";
+          version = "#{version}";
 
-		  packages = with beamPackages; with self; {
-		#{pkgs}
-		  };
-		in self
-		"""
-	end
+          src = fetchHex {
+            pkg = "#{hex_name}";
+            version = "${version}";
+            sha256 = "#{sha256}";
+          };
+
+          beamDeps = #{deps};
+        };
+    """
+  end
+
+  defp wrap(pkgs) do
+    """
+    { lib, beamPackages, overrides ? (x: y: {}) }:
+
+    let
+      buildRebar3 = lib.makeOverridable beamPackages.buildRebar3;
+      buildMix = lib.makeOverridable beamPackages.buildMix;
+      buildErlangMk = lib.makeOverridable beamPackages.buildErlangMk;
+
+      self = packages // (overrides self packages);
+
+      packages = with beamPackages; with self; {
+    #{pkgs}
+      };
+    in self
+    """
+  end
 end

--- a/lib/mix2nix/cli.ex
+++ b/lib/mix2nix/cli.ex
@@ -1,61 +1,67 @@
 defmodule Mix2nix.CLI do
+  def main(argv \\ []) do
+    {opt, args, _invalid} =
+      OptionParser.parse(argv,
+        switches: [version: :boolean, help: :boolean]
+      )
 
-	def main(argv \\ []) do
-		{opt, args, _invalid} =  OptionParser.parse( argv,
-			switches: [version: :boolean, help: :boolean])
+    cond do
+      opt[:version] ->
+        vsn = Application.spec(:mix2nix, :vsn) |> to_string()
+        IO.puts("mix2nix " <> vsn)
 
-		cond do
-			opt[:version] ->
-				vsn = Application.spec(:mix2nix, :vsn) |> to_string()
-				IO.puts("mix2nix " <> vsn)
-			opt[:help] ->
-				print_usage() |> IO.puts()
-			true ->
-				case lock_file_from_args(args) do
-					{:error, e} ->
-						IO.puts("#{e}")
-						System.halt(1)
-					{:ok, lock} ->
-						lock
-						|> Mix2nix.process
-						|> IO.puts()
-				end
-		end
-	end
+      opt[:help] ->
+        print_usage() |> IO.puts()
 
-	defp lock_file_from_args([lock]) do
-		case File.exists?(lock) do
-			true ->
-				{:ok, lock}
-			false ->
-				{:error, "Lock file #{lock} not found."}
-		end
-	end
+      true ->
+        case lock_file_from_args(args) do
+          {:error, e} ->
+            IO.puts("#{e}")
+            System.halt(1)
 
-	defp lock_file_from_args([_lock | _tail]) do
-		{:error, "Extra arguments not supported. Expected Usage: `mix2nix [filename]`"}
-	end
+          {:ok, lock} ->
+            lock
+            |> Mix2nix.process()
+            |> IO.puts()
+        end
+    end
+  end
 
-	defp lock_file_from_args([]) do
-		case File.exists?("mix.lock") do
-			true ->
-				{:ok, "mix.lock"}
-			false ->
-				{:error, "Unable to find mix.lock file in current directory."}
-		end
-	end
+  defp lock_file_from_args([lock]) do
+    case File.exists?(lock) do
+      true ->
+        {:ok, lock}
 
-	defp print_usage() do
-		~S"""
-		Usage:
-		mix2nix [file]
+      false ->
+        {:error, "Lock file #{lock} not found."}
+    end
+  end
 
-		Generates a set of nix package definitions from a mix.lock file. If no file
-		is specified, it will search the current directory.
+  defp lock_file_from_args([_lock | _tail]) do
+    {:error, "Extra arguments not supported. Expected Usage: `mix2nix [filename]`"}
+  end
 
-		Options:
-		--help     Show this help message.
-		--version  Show the application version.
-		"""
-	end
+  defp lock_file_from_args([]) do
+    case File.exists?("mix.lock") do
+      true ->
+        {:ok, "mix.lock"}
+
+      false ->
+        {:error, "Unable to find mix.lock file in current directory."}
+    end
+  end
+
+  defp print_usage() do
+    ~S"""
+    Usage:
+    mix2nix [file]
+
+    Generates a set of nix package definitions from a mix.lock file. If no file
+    is specified, it will search the current directory.
+
+    Options:
+    --help     Show this help message.
+    --version  Show the application version.
+    """
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -1,20 +1,20 @@
 defmodule Mix2nix.MixProject do
-	use Mix.Project
+  use Mix.Project
 
-	def project do
-		[
-			app: :mix2nix,
-			version: "0.1.8",
-			elixir: "~> 1.9",
-			start_permanent: Mix.env() == :prod,
-			escript: [main_module: Mix2nix.CLI]
-		]
-	end
+  def project do
+    [
+      app: :mix2nix,
+      version: "0.1.8",
+      elixir: "~> 1.9",
+      start_permanent: Mix.env() == :prod,
+      escript: [main_module: Mix2nix.CLI]
+    ]
+  end
 
-	# Run "mix help compile.app" to learn about applications.
-	def application do
-		[
-			extra_applications: [:logger]
-		]
-	end
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
 end

--- a/test/mix2nix_test.exs
+++ b/test/mix2nix_test.exs
@@ -1,8 +1,8 @@
 defmodule Mix2nixTest do
-	use ExUnit.Case
-	doctest Mix2nix
+  use ExUnit.Case
+  doctest Mix2nix
 
-	test "return nix expression from a map of dependencies" do
-		assert File.read!("./test/result.nix") == Mix2nix.process("./test/mix.lock")
-	end
+  test "return nix expression from a map of dependencies" do
+    assert File.read!("./test/result.nix") == Mix2nix.process("./test/mix.lock")
+  end
 end


### PR DESCRIPTION
I've been keen to contribute to mix2nix but have found it tricky to get started due to the particular formatting that the codebase uses.

At risk of starting a flame war, this PR standardises formatting to use the `mix format` defaults.

Hope this lands OK and isn't too pushy!

Alternatively, if you have the settings for a `.formatter.exs` that works with the codebase I'd love to see that added to the project's root.