### PR TITLE
Workaround for png

### DIFF
--- a/lib/mix2nix.ex
+++ b/lib/mix2nix.ex
@@ -168,5 +168,18 @@ defmodule Mix2nix do
     """
   end
 
+  defp hexpm_expression_extras("png", version) do
+    """
+          unpackPhase = ''
+            runHook preUnpack
+            unpackFile "$src"
+            chmod -R u+w -- hex-source-png-#{version}
+            mv hex-source-grpcbox-#{version} png
+            sourceRoot=png
+            runHook postUnpack
+          '';
+    """
+  end
+
   defp hexpm_expression_extras(_, _), do: ""
 end

--- a/lib/mix2nix.ex
+++ b/lib/mix2nix.ex
@@ -174,7 +174,7 @@ defmodule Mix2nix do
             runHook preUnpack
             unpackFile "$src"
             chmod -R u+w -- hex-source-png-#{version}
-            mv hex-source-grpcbox-#{version} png
+            mv hex-source-png-#{version} png
             sourceRoot=png
             runHook postUnpack
           '';

--- a/test/result.nix
+++ b/test/result.nix
@@ -160,6 +160,28 @@ let
       beamDeps = [ decimal ];
     };
 
+    png = buildRebar3 rec {
+      name = "png";
+      version = "0.2.1";
+
+      src = fetchHex {
+        pkg = "png";
+        version = "${version}";
+        sha256 = "279345e07108c604871a21f1c91f716810ab559af2b20d6f302e0a98265ef72e";
+      };
+
+      beamDeps = [];
+
+      unpackPhase = ''
+        runHook preUnpack
+        unpackFile "$src"
+        chmod -R u+w -- hex-source-png-0.2.1
+        mv hex-source-png-0.2.1 png
+        sourceRoot=png
+        runHook postUnpack
+      '';
+    };
+
     ranch = buildRebar3 rec {
       name = "ranch";
       version = "1.8.0";


### PR DESCRIPTION
Like grpcbox, png won't compile unless it is in a directory called 'png'.

See the grpcbox PR for more context: https://github.com/ydlr/mix2nix/pull/22