### PR TITLE
Use standard devShells.*.default to fix direnv

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,16 +10,25 @@
       supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-linux" "aarch64-darwin" ];
       forAllSystems = nixpkgs.lib.genAttrs supportedSystems;
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
-    in {
+    in
+    {
       packages = forAllSystems (system:
         let
           pkgs = nixpkgsFor.${system};
-        in {
+        in
+        {
           default = pkgs.callPackage ./default.nix { inherit pkgs; };
-
-          devShell = pkgs.mkShell {
-            buildInputs = with pkgs; [ elixir bashInteractive ];
-          };
         });
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgsFor.${system};
+        in
+        {
+          default = with pkgs; mkShell {
+            packages = [ elixir bashInteractive ];
+          };
+        }
+      );
     };
 }


### PR DESCRIPTION
`packages.*.devShell` requires a separate `nix develop .#devShell`, whereas this location lets `use flake` pick up the shell settings.