### PR TITLE
Don't emit warnings when built with Elixir 1.16.x

### DIFF
--- a/lib/mix2nix.ex
+++ b/lib/mix2nix.ex
@@ -17,7 +17,11 @@ defmodule Mix2nix do
   end
 
   defp read(filename) do
-    opts = [file: filename, warn_on_unnecessary_quotes: false]
+    opts = [
+      emit_warnings: false,
+      file: filename,
+      warn_on_unnecessary_quotes: false
+    ]
 
     with {:ok, contents} <- File.read(filename),
          {:ok, quoted} <- Code.string_to_quoted(contents, opts),


### PR DESCRIPTION
I have a project where we want to use a single version of Elixir for our project and mix2nix. This change adds the Elixir 1.16.x compatible option to ignore warnings when parsing the lock file. The 1.15.x option can coexist without issue.