### PR TITLE
Upgrade to nixpkgs 24.05

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705183652,
-        "narHash": "sha256-rnfkyUH0x72oHfiSDhuCHDHg3gFgF+lF8zkkg5Zihsw=",
+        "lastModified": 1717555607,
+        "narHash": "sha256-WZ1s48OODmRJ3DHC+I/DtM3tDRuRJlNqMvxvAPTD7ec=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "428544ae95eec077c7f823b422afae5f174dee4b",
+        "rev": "0b8e7a1ae5a94da2e1ee3f3030a32020f6254105",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-23.11",
+        "ref": "nixos-24.05",
         "type": "indirect"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "mix2nix: Generate a set of nix derivations from a mix.lock file";
 
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-23.11";
+    nixpkgs.url = "nixpkgs/nixos-24.05";
   };
 
   outputs = { self, nixpkgs }:

--- a/lib/mix2nix.ex
+++ b/lib/mix2nix.ex
@@ -135,9 +135,9 @@ defmodule Mix2nix do
           };
 
           beamDeps = #{deps};
-    """
-    <> hexpm_expression_extras(name)
-    <> "    };\n"
+    """ <>
+      hexpm_expression_extras(name) <>
+      "    };\n"
   end
 
   defp wrap(pkgs) do
@@ -165,8 +165,8 @@ defmodule Mix2nix do
           unpackPhase = ''
             runHook preUnpack
             unpackFile "$src"
-            chmod -R u+w -- hex-source-#{pkg_name}-${version}
-            mv hex-source-#{pkg_name}-${version} #{pkg_name}
+            chmod -R u+w -- #{pkg_name}-${version}
+            mv #{pkg_name}-${version} #{pkg_name}
             sourceRoot=#{pkg_name}
             runHook postUnpack
           '';


### PR DESCRIPTION
In 24.05, fetchHex removed the pname prefix. This means hex packages pulled with it will no longer have `hex-source-` in the unpacked directory name. Please see the [fetchHex update
commit](https://github.com/NixOS/nixpkgs/commit/4531cf76e4d5452ba1397c5d6a6ab811996d20fc)